### PR TITLE
Dropped all usage of inline functions

### DIFF
--- a/lib/exists_balancer.cpp
+++ b/lib/exists_balancer.cpp
@@ -12,20 +12,19 @@ using namespace std;
 
 Config unwired_2_1_splitter = {{-1, -1}, {-1}};
 
-void inline wire_2_inputs_1_fixedOutput(Configs &configs, int n) {
+void wire_2_inputs_1_fixedOutput(Configs &configs, int n) {
   for (int out = -1; out < n; ++out) {
     configs.push_back({{-1, -1}, {out, -1}});
   }
 }
 
-void inline wire_2_fixedInputs_1_output(Configs &configs, int in1, int in2,
-                                        int n) {
+void wire_2_fixedInputs_1_output(Configs &configs, int in1, int in2, int n) {
   for (int out1 = -1; out1 < n; ++out1) {
     configs.push_back({{in1, in2}, {out1, -1}});
   }
 }
 
-void inline wire_1_fixedInput_1_output(Configs &configs, int in1, int n) {
+void wire_1_fixedInput_1_output(Configs &configs, int in1, int n) {
   for (int out1 = -1; out1 < n; ++out1) {
     configs.push_back({{in1}, {out1, -1}});
   }

--- a/lib/network_tools.cpp
+++ b/lib/network_tools.cpp
@@ -101,7 +101,7 @@ Matrix transpose(Matrix matrix) {
   return transpose_matrix;
 }
 
-inline void sortMatrix(Matrix& matrix) {
+void sortMatrix(Matrix& matrix) {
   while (true) {
     Matrix old_matrix = matrix;
 

--- a/lib/network_tools.hpp
+++ b/lib/network_tools.hpp
@@ -42,7 +42,7 @@ Row getColumn(Matrix matrix, int column_position);
 Matrix transpose(Matrix matrix);
 
 // Put matrix into lexicographic normal form
-inline void sortMatrix(Matrix& matrix);
+void sortMatrix(Matrix& matrix);
 
 //////////////////////////////
 // Network operations

--- a/lib/utils.hpp
+++ b/lib/utils.hpp
@@ -8,10 +8,10 @@
 #include <vector>
 
 // Log a string to console
-inline void log(std::string message) { std::cout << message << "\n"; }
+void log(std::string message) { std::cout << message << "\n"; }
 
 // Log a vector<double> to console
-inline void log(std::vector<double> row) {
+void log(std::vector<double> row) {
   // log numbers with full precision, usually 17 digits
   std::cout.precision(std::numeric_limits<double>::max_digits10);
 
@@ -25,7 +25,7 @@ inline void log(std::vector<double> row) {
 
 // Throw exception if index is out of bounds of vector
 template <class T>
-inline void vectorGuard(std::vector<T> v, int index) {
+void vectorGuard(std::vector<T> v, int index) {
   if (index < 0 || index > v.size()) {
     throw "Index out of bounds";
   }


### PR DESCRIPTION
Reasons Pro:
```diff
+ Increases readability
+ Inline is unnecessary at this point (premature optimization)
+ Inline functions complicate the debug stack
```

Reasons Con:
```
None we could think of
```

This PR changes these functions:
- exists_balancer: 
  - wire_2_inputs_1_fixedOutput
  - wire_2_fixedInputs_1_output
  -  wire_1_fixedInput_1_output
- network_tools: sortMatrix
- utils: log
