### PR TITLE
Feature/drop using namespace std

### DIFF
--- a/lib/exists_balancer.cpp
+++ b/lib/exists_balancer.cpp
@@ -8,7 +8,8 @@
 #include "network_tools.hpp"
 #include "types.hpp"
 
-using namespace std;
+using std::set;
+using std::vector;
 
 Config unwired_2_1_splitter = {{-1, -1}, {-1}};
 

--- a/lib/network_tools.cpp
+++ b/lib/network_tools.cpp
@@ -10,6 +10,8 @@
 #include "types.hpp"
 #include "utils.hpp"
 
+using std::vector;
+
 Row constRow(int size, double value) {
   Row const_row;
   for (int i = 0; i < size; ++i) {

--- a/lib/network_tools.hpp
+++ b/lib/network_tools.hpp
@@ -49,13 +49,13 @@ inline void sortMatrix(Matrix& matrix);
 //////////////////////////////
 
 // Represents a splitter's connection to an existing network
-using Wiring = vector<int>;
+using Wiring = std::vector<int>;
 
 // A Pair of wirings for a splitter's input and output
-using Config = vector<Wiring>;
+using Config = std::vector<Wiring>;
 
 // A collection of wirings building a network
-using Configs = vector<Config>;
+using Configs = std::vector<Config>;
 
 // Determine if a wiring value is a connected or unconnected (-1)
 bool isWired(int connection);

--- a/lib/output_ratios.cpp
+++ b/lib/output_ratios.cpp
@@ -7,6 +7,8 @@
 #include "network_tools.hpp"
 #include "types.hpp"
 
+using std::max;
+
 Matrix outputRatios(Network nodes) {
   int network_size = nodes.size();
 

--- a/lib/types.hpp
+++ b/lib/types.hpp
@@ -3,19 +3,18 @@
 #pragma once
 #include <string>
 #include <vector>
-using namespace std;
 
 struct Node {
-  vector<Node *> inputs;
-  vector<Node *> outputs;
+  std::vector<Node *> inputs;
+  std::vector<Node *> outputs;
 };
 
-using Row = vector<double>;
-using Matrix = vector<Row>;
-using Network = vector<Node *>;
+using Row = std::vector<double>;
+using Matrix = std::vector<Row>;
+using Network = std::vector<Node *>;
 
 struct TestNet {
-  string name;
+  std::string name;
   Network network;
   Row ratios;
 };


### PR DESCRIPTION
This fixes headers and closes #3.

 Additionally it uses truncated namespaces in cpp files:

Before:
```c++
using namespace std;  // but which parts?
```

After:
```c++
using std::vector;
using std::set;
```

Truncated namespaces:
  - make files more readable
  - reduce the risk of namespace collisions

See:
- [Why “using namespace std” is considered bad practice](https://www.geeksforgeeks.org/using-namespace-std-considered-bad-practice/)
- [SO question 1452721](https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice)