### PR TITLE
Add a Build Example script and an example for profiling existsBalancer

### DIFF
--- a/example.sh
+++ b/example.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Usage:
+#   ./example.sh : build optimized debug target
+
+set -o errexit # Exit on errors
+
+INCLUDE="lib/"
+SRC="lib/*.cpp"
+TESTS="tests/*.cpp"
+EXAMPLE_BINARY="bin/test_example"
+
+OPTIM='-g -O3'
+
+clean() {
+  echo Cleaning old example
+  rm -rf $EXAMPLE_BINARY
+}
+
+build() {
+  echo Building example
+  clang++ $OPTIM -std=c++17 \
+    $SRC $TESTS -I $INCLUDE \
+    -o $EXAMPLE_BINARY
+  echo Done!
+}
+
+main() {
+  clean && build
+}
+
+main

--- a/tests/profile_existsBalancer.cpp
+++ b/tests/profile_existsBalancer.cpp
@@ -1,0 +1,10 @@
+#include "../lib/exists_balancer.hpp"
+#include "catch2/catch.hpp"
+
+TEST_CASE("profile_existsBalancer", "[!hide]") {
+  REQUIRE(existsBalancer(4, 4, 4));
+}
+
+TEST_CASE("burn_existsBalancer", "[!hide]") {
+  REQUIRE(existsBalancer(5, 5, 6));
+}

--- a/tests/test_existsBalancer.cpp
+++ b/tests/test_existsBalancer.cpp
@@ -5,19 +5,8 @@
 #include "../lib/exists_balancer.hpp"
 #include "catch2/catch.hpp"
 
-unsigned int Factorial2(unsigned int number) {
-  return number <= 1 ? number : Factorial2(number - 1) * number;
-}
-
 TEST_CASE("existsBalancer") {
   SECTION("Balancer 1-1-1 exists") { REQUIRE(existsBalancer(1, 1, 1)); }
   SECTION("Balancer 3-3-2 doesn't exist") { REQUIRE(!existsBalancer(3, 3, 2)); }
   SECTION("Balancer 4-4-4 exists") { REQUIRE(existsBalancer(4, 4, 4)); }
 }
-
-// vector<vector<double>> my_network = {{0.1, 0.2, 0.3, 0.4}, {0.5, 0.6, 0.7,
-// 0.8}};
-
-// vector<vector<double>> new_network = addSplitter(my_network, {0}, {1, -1});
-
-// bool balancerExists = existsBalancer(5, 5, 6);


### PR DESCRIPTION
Changes:

1. Running `example.sh` now builds an optimized test binary `bin/test_example`
   - This enables debugging (clang `-g`)
   - It also enables level 3 optimization (clang `-03`) 

2. We've added new optimization targets in `tests/profile_existsBalancer.cpp`. 
     The available profiles are:
    
     - `profile_existsBalancer` -         runs `existsBalancer(4, 4, 4)`
     - `burn_existsBalancer`-        runs `existsBalancer(5, 5, 6)`

Note: We skip these profiles during ordinary testing by adding the `[!hide]` flag to their test cases:

```c++
TEST_CASE("profile_existsBalancer", "[!hide]") {
  REQUIRE(existsBalancer(4, 4, 4));
}

TEST_CASE("burn_existsBalancer", "[!hide]") {
  REQUIRE(existsBalancer(5, 5, 6));
}
```

Run the profiles like:
> ./bin/test_example <profile_name>

For example, to run the burn-in test, do:
> ./bin/test_example burn_existsBalancer